### PR TITLE
Refactor and fix code style

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ var booleanOperators = {
 
 Also you must pass `parseOperand` to evaluate methods. `parseOperand` will be
 used to get value of every operand. Operand is a sequence of non-whitespace
-characters that is not equals to any operator or bracket.
+characters that is not equal to any operator or bracket.
 
 **Note:** `parseOperand` must return value compatible with defined operators.
 

--- a/lib/expressionify.js
+++ b/lib/expressionify.js
@@ -24,39 +24,41 @@ Expression.prototype._validateParams = function(params, requiredParams) {
 Expression.prototype._buildRpn = function(expression, params) {
 	this._validateParams(params, ['operators']);
 
-	var stack = [];
 	var operators = params.operators;
 	var tokens = parseExpression(expression, params);
 
-	return tokens
-		.reduce(function(output, token) {
-			if (token in operators) {
-				while (
-					utils.peek(stack) in operators &&
-					(
-						operators[token].type === 'binary' ?
-						operators[token].priority <= operators[utils.peek(stack)].priority :
-						operators[token].priority < operators[utils.peek(stack)].priority
-					)
-				) {
-					output.push(stack.pop());
-				}
-				stack.push(token);
-			} else if (token === '(') {
-				stack.push(token);
-			} else if (token === ')') {
-				while (utils.peek(stack) !== '(') {
-					output.push(stack.pop());
-				}
-				stack.pop();
-			} else {
-				// if token is operand
-				output.push(token);
+	var rpn = [];
+	var stack = [];
+	tokens.forEach(function(token) {
+		if (token in operators) {
+			while (
+				utils.peek(stack) in operators &&
+				(
+					operators[token].type === 'binary' ?
+					operators[token].priority <= operators[utils.peek(stack)].priority :
+					operators[token].priority < operators[utils.peek(stack)].priority
+				)
+			) {
+				rpn.push(stack.pop());
 			}
+			stack.push(token);
 
-			return output;
-		}, [])
-		.concat(stack.reverse());
+		} else if (token === '(') {
+			stack.push(token);
+
+		} else if (token === ')') {
+			while (utils.peek(stack) !== '(') {
+				rpn.push(stack.pop());
+			}
+			stack.pop();
+
+		} else {
+			// if token is operand
+			rpn.push(token);
+		}
+	});
+
+	return rpn.concat(stack.reverse());
 };
 
 Expression.prototype.evaluate = function(params) {

--- a/lib/expressionify.js
+++ b/lib/expressionify.js
@@ -45,8 +45,9 @@ Expression.prototype._buildRpn = function(expression, params) {
 			} else if (token === '(') {
 				stack.push(token);
 			} else if (token === ')') {
-				while (utils.peek(stack) !== '(')
+				while (utils.peek(stack) !== '(') {
 					output.push(stack.pop());
+				}
 				stack.pop();
 			} else {
 				// if token is operand

--- a/lib/parseExpression.js
+++ b/lib/parseExpression.js
@@ -12,7 +12,7 @@ var expressionRules = {
 	'end': []
 };
 
-var specialSymbols = '{}[]^/|?*+$';
+var specialSymbols = '{}[]$^/*+-%:&|';
 var specialSymbolRegexp = new RegExp(
 	'(\\' + specialSymbols.split('').join('|\\') + ')', 'g'
 );

--- a/lib/parseExpression.js
+++ b/lib/parseExpression.js
@@ -12,23 +12,21 @@ var expressionRules = {
 	'end': []
 };
 
-var specialSymbols = '{}[]^/|?*+$'.split('');
-var specialSymbolRegexpList = [];
-specialSymbols.forEach(function(symbol) {
-	specialSymbolRegexpList.push(new RegExp('\\' + symbol, 'g'));
-});
+var specialSymbols = '{}[]^/|?*+$';
+var specialSymbolRegexp = new RegExp(
+	'(\\' + specialSymbols.split('').join('|\\') + ')', 'g'
+);
 
 var createNextTokenGetter = function(params) {
-	// prepare regexps for parsing
+	// escape special symbols in operators
 	var operators = [];
-	
-	for (var key in params.operators) {
-		// escape special symbols in operators
-		specialSymbols.forEach(function(symbol, index) {
-			key = key.replace(specialSymbolRegexpList[index], '\\' + symbol);
-		});
-		operators.push(key);
+	for (var operator in params.operators) {
+		operators.push(
+			operator.replace(specialSymbolRegexp, '\\$&')
+		);
 	}
+
+	// prepare regexps for parsing
 	var operatorRegexp = new RegExp('^(' + operators.join('|') + ')');
 	var notOperandTokenRegexp = new RegExp(
 		'(' + operators.concat(['\\(', '\\)', '\\s', '$']).join('|') + ')'
@@ -72,8 +70,7 @@ var createNextTokenGetter = function(params) {
 		}
 
 		// check for operator
-		var operatorMatches = (value + expression.substr(index))
-			.match(operatorRegexp);
+		var operatorMatches = operatorRegexp.exec(value + expression.substr(index));
 		if (operatorMatches && operatorMatches.length > 0) {
 			value = operatorMatches[0];
 			index += value.length - 1;
@@ -117,8 +114,8 @@ module.exports = function(expression, params) {
 		}
 
 		// update brackets counter
-		if (currentToken.type === '(') { bracketsCounter++; }
-		if (currentToken.type === ')') { bracketsCounter--; }
+		if (currentToken.type === '(') bracketsCounter++;
+		if (currentToken.type === ')') bracketsCounter--;
 
 		tokens.push(currentToken);
 		currentToken = getNextToken(expression, currentToken.currentIndex);

--- a/test/parseExpression.js
+++ b/test/parseExpression.js
@@ -126,4 +126,19 @@ describe('parseExpression', function() {
 		);
 	});
 
+	it('should escape all special symbols in operators',
+		function() {
+			var tokens = parseExpression(
+				'a || b && c',
+				{
+					operators: {
+						'||': { type: 'binary' },
+						'&&': { type: 'binary' }
+					}
+				}
+			);
+
+			expect(tokens).to.eql(['a', '||', 'b', '&&', 'c']);
+		}
+	);
 });


### PR DESCRIPTION
Fix code style in project, refactor `parseExpression`, remove `reduce()` call to backward compatibility.
